### PR TITLE
GAS V8 Runtime updates

### DIFF
--- a/GmailUtils.gs
+++ b/GmailUtils.gs
@@ -476,8 +476,8 @@ function formatEmails_(emails) {
  * @param {string} class
  * @return {boolean}
  */
-function isa_(obj, class) {
-  return typeof obj == 'object' && typeof obj.constructor == 'undefined' && obj.toString() == class;
+function isa_(obj, className) {
+  return typeof obj == 'object' && (typeof obj.constructor == 'undefined' || typeof obj.constructor == 'function') && obj.toString() == className;
 }
 
 /**
@@ -500,8 +500,21 @@ function defaults_(options, defaults) {
  * @return {string}
  */
 function localTimezone_() {
-  var timezone = new Date().toTimeString().match(/\(([a-z0-9]+)\)/i);
-  return timezone.length ? timezone[1] : 'GMT';
+  // 19:26:50 GMT-0700 (Pacific Daylight Time)
+  // 19:29:40 GMT-0700 (PDT)
+  //Logger.log('Hello=' + new Date().toTimeString());
+  //console.log('Hello=' + new Date().toTimeString());
+  //var timezone = new Date().toTimeString().match(/\(([a-z 0-9]+)\)/i);
+  //return timezone.length ? timezone[1] : 'GMT';
+  var tz = gettz_();
+  return tz ? tz : 'GMT';
+}
+
+function gettz_() {
+  var d = new Date(); // now, or the specific date in question
+  var s = d.toLocaleString("en", {timeZoneName: "short"}).split(' ').pop();
+  //Logger.log(s);
+  return s;
 }
 
 /**
@@ -525,4 +538,3 @@ function md5_(str) {
     chr = (chr < 0 ? chr + 256 : chr).toString(16);
     return str + (chr.length==1?'0':'') + chr;
   },'');
-}

--- a/GmailUtils.gs
+++ b/GmailUtils.gs
@@ -538,3 +538,4 @@ function md5_(str) {
     chr = (chr < 0 ? chr + 256 : chr).toString(16);
     return str + (chr.length==1?'0':'') + chr;
   },'');
+}


### PR DESCRIPTION
I made two changes so that this works with the new Google Apps Script V8 Runtime. It should still work with the old version too, but I am not 100% sure about that.
1) change the check that uses "class" as an identifier ... GAS V8 does not appreciate that use of "class"
2) update the code that determines the current time zone to put into the email PDF, the regular expression doesn't work in V8 because the long name of the time zone is returned instead of the abbreviated version; updated the code to use another method